### PR TITLE
Bug fix: networking activity doesn't stop after the dismiss of the queueit viewcontroller

### DIFF
--- a/QueueITLib/QueueITViewController.m
+++ b/QueueITLib/QueueITViewController.m
@@ -80,7 +80,9 @@ static NSString * const JAVASCRIPT_GET_BODY_CLASSES = @"document.getElementsByTa
                     if ([targetUrl.host containsString:url.host]) {
                         self.isQueuePassed = YES;
                         [self.engine raiseQueuePassed];
-                        [self.host dismissViewControllerAnimated:YES completion:nil];
+                        [self.host dismissViewControllerAnimated:YES completion:^{
+                            [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+                        }];
                     } else if (navigationType == UIWebViewNavigationTypeLinkClicked && !isQueueUrl) {
                         [[UIApplication sharedApplication] openURL:[request URL]];
                         return NO;
@@ -121,7 +123,9 @@ static NSString * const JAVASCRIPT_GET_BODY_CLASSES = @"document.getElementsByTa
 {
     [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
     
-    [self.host dismissViewControllerAnimated:YES completion:nil];
+    [self.host dismissViewControllerAnimated:YES completion:^{
+        [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+    }];
 }
 
 @end


### PR DESCRIPTION
After dismissing the webview we need to make sure the app shared activity indicator is stopped too. If it doesn't stop we have a risk of getting to the host view controller with the activity indicator still running.